### PR TITLE
Fix SSL verification for GUI version fetch

### DIFF
--- a/mindsdb-main/mindsdb/api/http/initialize.py
+++ b/mindsdb-main/mindsdb/api/http/initialize.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from http import HTTPStatus
 
 import requests
+import certifi
 from flask import Flask, url_for, make_response, request, send_from_directory
 from flask.json import dumps
 from flask_compress import Compress
@@ -92,7 +93,17 @@ def custom_output_json(data, code, headers=None):
 def get_last_compatible_gui_version() -> Version:
     logger.debug("Getting last compatible frontend..")
     try:
-        res = requests.get('https://mindsdb-web-builds.s3.amazonaws.com/compatible-config.json', timeout=5)
+        res = requests.get(
+            'https://mindsdb-web-builds.s3.amazonaws.com/compatible-config.json',
+            timeout=5,
+            verify=certifi.where()
+        )
+    except requests.exceptions.SSLError as e:
+        logger.error(
+            "SSL verification failed while fetching compatible-config.json. "
+            "Ensure system certificates are installed or disable GUI autoupdate."
+        )
+        return False
     except (ConnectionError, requests.exceptions.ConnectionError) as e:
         logger.error(f"Is no connection. {e}")
         return False

--- a/mindsdb-main/requirements/requirements.txt
+++ b/mindsdb-main/requirements/requirements.txt
@@ -21,6 +21,7 @@ pydantic ~= 2.7.0
 mindsdb-evaluator == 0.0.17
 duckdb ~= 1.2.1
 requests == 2.32.3
+certifi
 dateparser==1.2.0
 dill == 0.3.6
 numpy


### PR DESCRIPTION
## Summary
- verify SSL with certifi when fetching the GUI version
- handle SSL errors with explicit log message
- list certifi in requirements

## Testing
- `python -m py_compile mindsdb/api/http/initialize.py`
- ❌ `make check` *(fails: FileNotFoundError: deptry.json)*
- ❌ `pytest -k nonexistingpattern` *(fails: command not found)*