### PR TITLE
Add FAQ about SSL certificate errors

### DIFF
--- a/mindsdb-main/docs/docs.json
+++ b/mindsdb-main/docs/docs.json
@@ -966,7 +966,8 @@
                   "faqs/persist-predictions",
                   "faqs/mindsdb-with-php",
                   "faqs/disposable-email-doman-and-openai",
-                  "faqs/missing-required-cpu-features"
+                  "faqs/missing-required-cpu-features",
+                  "faqs/ssl-certificate-verify-failed"
                 ]
               }
             ]

--- a/mindsdb-main/docs/faqs/ssl-certificate-verify-failed.mdx
+++ b/mindsdb-main/docs/faqs/ssl-certificate-verify-failed.mdx
@@ -1,0 +1,22 @@
+---
+title: SSL Certificate Verification Failed
+sidebarTitle: SSL Certificate Verification Failed
+---
+
+When starting MindsDB, you may see an `SSLCertVerificationError` in the logs if the host operating system is missing certificate authority (CA) certificates.
+
+## Solutions
+
+1. Install the system's CA certificates. If this isn't possible, you can use the certificates provided by the [`certifi`](https://pypi.org/project/certifi/) package:
+   ```bash
+   python -m certifi
+   ```
+   Then set the `SSL_CERT_FILE` environment variable to the path printed above so that Python uses these certificates.
+2. Alternatively, disable GUI autoupdate to prevent MindsDB from attempting to download updates:
+   - In the configuration file set:
+     ```json
+     {
+       "gui": { "autoupdate": false }
+     }
+     ```
+   - Or start MindsDB with the `--no_studio` flag.


### PR DESCRIPTION
## Summary
- document SSLCertVerificationError in FAQs
- add instructions on using certifi or disabling autoupdate
- add page to docs navigation

## Testing
- `pre-commit run --files docs/faqs/ssl-certificate-verify-failed.mdx docs/docs.json` *(fails: command not found)*