### PR TITLE
Fix warnings and remove print statement

### DIFF
--- a/mindsdb-main/scripts/snowflake_test.py
+++ b/mindsdb-main/scripts/snowflake_test.py
@@ -108,7 +108,7 @@ async def run_query(sql: str):
         },
     )
     result = snowflake_db.query(sql).fetch()
-    print(result)
+    logger.info("Query result: %s", result)
 
 
 async def main():

--- a/mindsdb-main/tests/scripts/check_print_statements.py
+++ b/mindsdb-main/tests/scripts/check_print_statements.py
@@ -15,7 +15,7 @@ def check_for_print_statements():
         - set(["mindsdb/__main__.py"])
     )
 
-    pattern = re.compile("\sprint\(")  # noqa: W605
+    pattern = re.compile(r"\sprint\(")  # noqa: W605
 
     failed_files = []
 

--- a/mindsdb-main/tests/scripts/check_requirements.py
+++ b/mindsdb-main/tests/scripts/check_requirements.py
@@ -5,7 +5,7 @@ import subprocess
 import os
 import json
 
-pattern = '\=|~|>|<| |\n|#|\['  # noqa: W605
+pattern = r"\=|~|>|<| |\n|#|\["  # noqa: W605
 
 
 def get_requirements_from_file(path):
@@ -270,7 +270,7 @@ def check_relative_reqs():
 
     # regex for finding relative imports of handlers like "from ..file_handler import FileHandler"
     # we're going to treat these as errors (and suggest using absolute imports instead)
-    relative_import_pattern = re.compile("(?:\s|^)(?:from|import) \.\.\w+_handler")  # noqa: W605
+    relative_import_pattern = re.compile(r"(?:\s|^)(?:from|import) \.\.\w+_handler")  # noqa: W605
 
     def get_relative_requirements(files):
         """Find entries in a requirements.txt that are including another requirements.txt"""
@@ -290,7 +290,8 @@ def check_relative_reqs():
         # regex for finding imports of other handlers like "from mindsdb.integrations.handlers.file_handler import FileHandler"
         # excludes the current handler importing parts of itself
         import_pattern = re.compile(
-            f"(?:\s|^)(?:from|import) mindsdb\.integrations\.handlers\.(?!{handler_name}_handler)\w+_handler")  # noqa: W605
+            rf"(?:\s|^)(?:from|import) mindsdb\.integrations\.handlers\.(?!{handler_name}_handler)\w+_handler"
+        )  # noqa: W605
 
         # requirements entries for this handler that point to another handler's requirements file
         required_handlers = get_relative_requirements(

--- a/mindsdb-main/tests/scripts/check_version.py
+++ b/mindsdb-main/tests/scripts/check_version.py
@@ -4,20 +4,32 @@ import sys
 from mindsdb.__about__ import __version__
 
 # PEP440: https://www.python.org/dev/peps/pep-0440/
-RELEASE_PATTERN = "^\d+(\.\d+)*$"  # noqa: W605
-PRERELEASE_PATTERN = "^\d+(\.\d+)*(a|b|rc)\d+$"  # noqa: W605
-
-version_str = sys.argv[1].replace('v', '')
-is_prerelease = sys.argv[2] == "true"
-
-if is_prerelease:
-    if re.match(PRERELEASE_PATTERN, version_str) is None:
-        raise Exception("Invalid prerelease version: %s" % version_str)
-elif re.match(RELEASE_PATTERN, version_str) is None:
-    raise Exception("Invalid release version: %s" % version_str)
+RELEASE_PATTERN = r"^\d+(\.\d+)*$"
+PRERELEASE_PATTERN = r"^\d+(\.\d+)*(a|b|rc)\d+$"
 
 
-if version_str != __version__:
-    raise Exception("Version mismatch between __about__.py and release tag: %s != %s" % (version_str, __version__))
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("Usage: check_version.py <version> <is_prerelease>")
+        return 1
 
-print(version_str)
+    version_str = sys.argv[1].replace('v', '')
+    is_prerelease = sys.argv[2] == "true"
+
+    if is_prerelease:
+        if re.match(PRERELEASE_PATTERN, version_str) is None:
+            raise Exception("Invalid prerelease version: %s" % version_str)
+    elif re.match(RELEASE_PATTERN, version_str) is None:
+        raise Exception("Invalid release version: %s" % version_str)
+
+    if version_str != __version__:
+        raise Exception(
+            "Version mismatch between __about__.py and release tag: %s != %s" % (version_str, __version__)
+        )
+
+    print(version_str)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- fix regex warnings in version check and handle missing arguments gracefully
- fix regex warnings in requirements and print statement checks
- remove print statement from `scripts/snowflake_test.py`

## Testing
- `PYTHONPATH=. python tests/scripts/check_version.py`
- `PYTHONPATH=. python tests/scripts/check_version.py v1.2.3 false` *(fails: Version mismatch)*
- `python tests/scripts/check_requirements.py` *(fails: FileNotFoundError: deptry.json)*
- `python tests/scripts/check_print_statements.py`